### PR TITLE
動作確認をファイル単体ごとに行えるようにした

### DIFF
--- a/app_option.rb
+++ b/app_option.rb
@@ -32,3 +32,10 @@ class AppOption
     ARGV
   end
 end
+
+return unless $0 == __FILE__
+
+option = AppOption.new
+p "dryrun:#{option.has?(:dryrun)}"
+p "short:#{option.has?(:short)}"
+p "get_extras:#{option.get_extras}"

--- a/ongeki_web_driver.rb
+++ b/ongeki_web_driver.rb
@@ -22,3 +22,8 @@ class OngekiWebDriver
     return driver
   end
 end
+
+return unless $0 == __FILE__
+
+driver = OngekiWebDriver.new.login
+driver.save_screenshot 'tmp.png'

--- a/player_data.rb
+++ b/player_data.rb
@@ -48,3 +48,15 @@ class PlayerData
     p "#{filename}に追加保存しました。"
   end
 end
+
+return unless $0 == __FILE__
+
+require './ongeki_web_driver'
+require './app_option'
+
+option = AppOption.new
+driver = OngekiWebDriver.new.login
+
+player_data = PlayerData.new
+player_data.collect(driver)
+player_data.save unless option.has?(:dryrun)

--- a/playlog.rb
+++ b/playlog.rb
@@ -137,3 +137,15 @@ class Playlog
     p "#{filename}に保存しました。"
   end
 end
+
+return unless $0 == __FILE__
+
+require './ongeki_web_driver'
+require './app_option'
+
+option = AppOption.new
+driver = OngekiWebDriver.new.login
+
+playlog = Playlog.new
+playlog.collect_detail(driver, !option.has?(:short))
+playlog.save unless option.has?(:dryrun)


### PR DESCRIPTION
# 概要

webページにアクセスしている特性上、すべての処理を行うと時間がかかるので、単体で実行できるようにしました。

optionで何を実行するか切り分けるのも考えたのですが、数が増えていくとめんどくさそうなのでpythonみたいな書き方を選択した。(rubyで一般的なのかは謎)