### PR TITLE
出力結果を少し汎用的なものにした

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ongeki-recorder
 
-オンゲキのプレイ履歴を収集するやつ。
+オンゲキのプレイ履歴とプレイヤーデータを収集するやつ。
 要スタンダードコース以上です。
 
 https://github.com/Oshiumi/chunithm-recoder を参考にしてます。
@@ -51,11 +51,15 @@ bundle install --path=vendor/bundle
 
 `ONGEKI_SEGA_ID`の`your_id`と`ONGEKI_PASSWORD`の`your_password`を書き換える
 
-下記コマンドををongeki-recorder直下で実行。tmp.csvが作られます。
+下記コマンドををongeki-recorder直下で実行。playlog_YYYYmmdd-HHMMSS.csvとplayer_data.csvに保存されます。
 ```
 bundle exec ruby app.rb
 ```
 
 # 実行結果
 
-<img width="493" alt="aaa" src="https://user-images.githubusercontent.com/2544432/45429672-b9bd8380-b6de-11e8-80c1-2b69fb28be06.png">
+playlog_YYYYmmdd-HHMMSS.csv
+<img width="746" alt="playlog" src="https://user-images.githubusercontent.com/2544432/46259172-d2b49a00-c510-11e8-8886-61e66e442c28.png">
+
+player_data.csv
+<img width="748" alt="player_data" src="https://user-images.githubusercontent.com/2544432/46259202-22936100-c511-11e8-9474-2747bde33ba8.png">

--- a/player_data.rb
+++ b/player_data.rb
@@ -51,7 +51,7 @@ class PlayerData
       total_technical_scores << driver.find_element(:xpath, '//td[contains(@class, "gray_line f_b")]').text.gsub(/,/, '_').to_i
     end
 
-    @record="#{now},#{name},#{trophy},#{total_track},#{money},#{total_money},#{reincarnation*100+lv},#{battle_point},#{rating},#{max_rating},#{jewels.join(",")},#{total_battle_scores.join(",")},#{total_technical_scores.join(",")}"
+    @record="#{now},#{name},#{trophy},#{total_track},#{money},#{total_money},#{reincarnation*100+lv},#{battle_point},#{rating},#{max_rating},#{total_battle_scores.join(",")},#{total_technical_scores.join(",")},#{jewels.join(",")}"
 
     p @record
   end

--- a/player_data.rb
+++ b/player_data.rb
@@ -20,18 +20,19 @@ class PlayerData
 
     # ジュエル
     driver.navigate.to 'https://ongeki-net.com/ongeki-mobile/record/'
-
-    jewel_wild = driver.find_element(:xpath, '//span[contains(@class, "v_m p_3 f_14 gray")]').text.gsub(/,/, '_').to_i
     jewels = driver.find_elements(:xpath, '//span[contains(@class, "v_m p_3 f_14 white")]').map(&:text).map{ |s| s.gsub(/,/, '_').to_i}
+    jewel_wild = driver.find_element(:xpath, '//span[contains(@class, "v_m p_3 f_14 gray")]').text.gsub(/,/, '_').to_i
+    jewels << jewel_wild
 
-    # todo:親密度とりあえず柚子だけ
-    driver.navigate.to 'https://ongeki-net.com/ongeki-mobile/character/characterDetail/?idx=1001'
+    # # todo:親密度とりあえず柚子だけ
+    # # 必要なくなったので閉じる
+    # driver.navigate.to 'https://ongeki-net.com/ongeki-mobile/character/characterDetail/?idx=1001'
 
-    friendly_image_numbers = driver.find_element(:xpath, '//div[contains(@class, "character_friendly_conainer f_l")]')
-                     .find_elements(:tag_name, 'img')
-                     .map{|e| e.property('src').scan(/[0-9]+/)}
+    # friendly_image_numbers = driver.find_element(:xpath, '//div[contains(@class, "character_friendly_conainer f_l")]')
+    #                  .find_elements(:tag_name, 'img')
+    #                  .map{|e| e.property('src').scan(/[0-9]+/)}
 
-    friendly_yuzu = friendly_image_numbers[4][0].to_i * 100 + friendly_image_numbers[1][0].to_i + friendly_image_numbers[2][0].to_i
+    # friendly_yuzu = friendly_image_numbers[4][0].to_i * 100 + friendly_image_numbers[1][0].to_i + friendly_image_numbers[2][0].to_i
 
     # トータルハイスコア
     driver.navigate.to 'https://ongeki-net.com/ongeki-mobile/ranking/totalHiscore/'
@@ -50,7 +51,7 @@ class PlayerData
       total_technical_scores << driver.find_element(:xpath, '//td[contains(@class, "gray_line f_b")]').text.gsub(/,/, '_').to_i
     end
 
-    @record="#{now},#{name},#{trophy},#{total_track},,#{total_money},#{reincarnation*100+lv},#{battle_point},#{rating},#{max_rating},,,,,,,#{friendly_yuzu},#{jewel_wild},#{jewels[-1]},#{total_battle_scores.join(",")},#{total_technical_scores.join(",")}"
+    @record="#{now},#{name},#{trophy},#{total_track},#{money},#{total_money},#{reincarnation*100+lv},#{battle_point},#{rating},#{max_rating},#{jewels.join(",")},#{total_battle_scores.join(",")},#{total_technical_scores.join(",")}"
 
     p @record
   end

--- a/playlog.rb
+++ b/playlog.rb
@@ -80,8 +80,8 @@ class Playlog
                      }
 
       # record << {
-      #    'title' => title,
       #    'date' => date,
+      #    'title' => title,
       #    'difficulty' => difficulty,
       #    'battle_rank' => battle_rank,
       #    'battle_score' => battle_score,
@@ -118,7 +118,7 @@ class Playlog
       #    'card_image_name3' => card_image_name3,
       # }
 
-      @record << "#{title},#{date},#{difficulty},#{battle_rank},#{battle_score},#{over_damage},#{technical_rank},#{technical_score},#{result},#{full_bell},#{full_combo},#{max_combo},#{score_critical_break},#{score_break},#{score_hit},#{score_miss},#{score_bell},#{score_damage},#{score_detial_tap},#{score_detial_hold},#{score_detial_flick},#{score_detial_side_tap},#{score_detial_side_hold},#{place_name},#{matching1},#{matching2},#{matching3},#{card_level1},#{card_power1},#{card_image_name1},#{card_level2},#{card_power2},#{card_image_name2},#{card_level3},#{card_power3},#{card_image_name3}"
+      @record << "#{date},#{title},#{difficulty},#{battle_rank},#{battle_score},#{over_damage},#{technical_rank},#{technical_score},#{result},#{full_bell},#{full_combo},#{max_combo},#{score_critical_break},#{score_break},#{score_hit},#{score_miss},#{score_bell},#{score_damage},#{score_detial_tap},#{score_detial_hold},#{score_detial_flick},#{score_detial_side_tap},#{score_detial_side_hold},#{place_name},#{matching1},#{matching2},#{matching3},#{card_level1},#{card_power1},#{card_image_name1},#{card_level2},#{card_power2},#{card_image_name2},#{card_level3},#{card_power3},#{card_image_name3}"
     end
 
     p @record

--- a/playlog.rb
+++ b/playlog.rb
@@ -125,7 +125,7 @@ class Playlog
   end
 
   def save
-    filename = 'tmp.csv'
+    filename = "playlog_#{Time.now.strftime('%Y%m%d_%H%M%S')}.csv"
 
     File.open(filename, 'w') do |f|
       @record.each do |r|


### PR DESCRIPTION
# 概要

個人的な都合でカンマの数が多かったり、マニー出力していなかったり、ジュエルもエンドジュエルだけだったり、親密度が柚子だけだったのを修正しました。

親密度はすべて出力が安定し無さそうだった(並び順が人によってバラバラ)のでコメントアウトして収集から行っていません。

また、出力ファイル名もひとまず日付のファイルにしました。（本当は重複弾いて1個のファイルに溜め込みたい）

