### PR TITLE
日付順にplaylogを出力するようにした

### DIFF
--- a/playlog.rb
+++ b/playlog.rb
@@ -16,9 +16,14 @@ class Playlog
   end
 
   def collect_detail(driver, all)
-    num = all ? 50 : 1
+    driver.navigate.to "https://ongeki-net.com/ongeki-mobile/record/playlog/"
+
+    # <input type="hidden" name="idx" value="2">
+    page_numbers = driver.find_elements(:name, 'idx').map{|e| e.property('value').to_i}
+    page_numbers = page_numbers[0, 1] unless all
+
     @record = []
-    num.times do |i|
+    for i in page_numbers.reverse do
       playlog_detail_url="https://ongeki-net.com/ongeki-mobile/record/playlogDetail/?idx=#{i}"
       puts "#{playlog_detail_url}を解析中…"
       driver.navigate.to playlog_detail_url


### PR DESCRIPTION
# 概要

今まではページ数値順の出力だった
```
https://ongeki-net.com/ongeki-mobile/record/playlogDetail/?idx=0を解析中…
https://ongeki-net.com/ongeki-mobile/record/playlogDetail/?idx=1を解析中…
https://ongeki-net.com/ongeki-mobile/record/playlogDetail/?idx=2を解析中…
https://ongeki-net.com/ongeki-mobile/record/playlogDetail/?idx=3を解析中…
https://ongeki-net.com/ongeki-mobile/record/playlogDetail/?idx=4を解析中…
https://ongeki-net.com/ongeki-mobile/record/playlogDetail/?idx=5を解析中…
https://ongeki-net.com/ongeki-mobile/record/playlogDetail/?idx=6を解析中…
```
でも、これだと日付順ではない！ので、一覧からidxの並び順を取得して、その順番に解析するようにした。
下を最新のものにしたいのでreverseした。

変更後
```
https://ongeki-net.com/ongeki-mobile/record/playlogDetail/?idx=3を解析中…
https://ongeki-net.com/ongeki-mobile/record/playlogDetail/?idx=4を解析中…
https://ongeki-net.com/ongeki-mobile/record/playlogDetail/?idx=5を解析中…
https://ongeki-net.com/ongeki-mobile/record/playlogDetail/?idx=6を解析中…
https://ongeki-net.com/ongeki-mobile/record/playlogDetail/?idx=7を解析中…
https://ongeki-net.com/ongeki-mobile/record/playlogDetail/?idx=8を解析中…
https://ongeki-net.com/ongeki-mobile/record/playlogDetail/?idx=9を解析中…
…
https://ongeki-net.com/ongeki-mobile/record/playlogDetail/?idx=47を解析中…
https://ongeki-net.com/ongeki-mobile/record/playlogDetail/?idx=48を解析中…
https://ongeki-net.com/ongeki-mobile/record/playlogDetail/?idx=49を解析中…
https://ongeki-net.com/ongeki-mobile/record/playlogDetail/?idx=0を解析中…
https://ongeki-net.com/ongeki-mobile/record/playlogDetail/?idx=1を解析中…
https://ongeki-net.com/ongeki-mobile/record/playlogDetail/?idx=2を解析中…
```