### PR TITLE
イベント未参加時に、player_dataが取得できず失敗するのを修正

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -10,11 +10,6 @@ option = AppOption.new
 driver = OngekiWebDriver.new.login
 now = Time.now
 
-# レコードのプレイ履歴収集
-playlog = Playlog.new
-playlog.collect_detail(driver, !option.has?(:short))
-playlog.save(now) unless option.has?(:dryrun)
-
 # プレイヤーデータ収集
 player_data = PlayerData.new
 player_data.collect(driver, now)
@@ -29,6 +24,11 @@ bp_target_music.save(now) unless option.has?(:dryrun)
 rating_target_music = RatingTargetMusic.new
 rating_target_music.collect(driver, now)
 rating_target_music.save(now) unless option.has?(:dryrun)
+
+# レコードのプレイ履歴収集
+playlog = Playlog.new
+playlog.collect_detail(driver, !option.has?(:short))
+playlog.save(now) unless option.has?(:dryrun)
 
 # 楽曲詳細
 music_detail = MusicDetail.new

--- a/player_data.rb
+++ b/player_data.rb
@@ -57,7 +57,7 @@ class PlayerData
       event_ranking_url="https://ongeki-net.com/ongeki-mobile/event/ranking/?idx=#{i}"
       puts "#{event_ranking_url}を解析中…"
       driver.navigate.to event_ranking_url
-      nums = driver.find_elements(:xpath, '//span[contains(@class, "f_20 f_b")]').map{|e| e.text.scan(/[0-9,]+/).first.gsub(/,/, '_').to_i}
+      nums = driver.find_elements(:xpath, '//span[contains(@class, "f_20 f_b")]').map{|e| e.text.scan(/[0-9,]+/).first&.gsub(/,/, '_').to_i}
 
       next if nums.empty?
 


### PR DESCRIPTION
```
https://ongeki-net.com/ongeki-mobile/event/ranking/?idx=99010を解析中…
Traceback (most recent call last):
    5: from app.rb:20:in `<main>'
    4: from /Users/fumi/git/ongeki-recorder/player_data.rb:56:in `collect'
    3: from /Users/fumi/git/ongeki-recorder/player_data.rb:56:in `each'
    2: from /Users/fumi/git/ongeki-recorder/player_data.rb:60:in `block in collect'
    1: from /Users/fumi/git/ongeki-recorder/player_data.rb:60:in `map'
/Users/fumi/git/ongeki-recorder/player_data.rb:60:in `block (2 levels) in collect': undefined method `gsub' for nil:NilClass (NoMethodError)
```

の修正。イベント未参加時は
```
― pt
― 位
```
という表示だった。
<img width="484" alt="2018-11-15 14 28 15" src="https://user-images.githubusercontent.com/2544432/48549382-fe4de100-e912-11e8-8619-5d40f5e93383.png">
